### PR TITLE
Check for GLIBC rather than GNUC for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG ALPINE_VERSION=3.10
+FROM alpine:${ALPINE_VERSION}
+
+COPY . /mve
+
+RUN apk add --no-cache \
+        make \
+        g++ \
+        jpeg-dev \
+        libpng-dev \
+        tiff-dev \
+        mesa-dev \
+    && cd /mve \
+    && mkdir bin \
+    && make all
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ RUN apk add --no-cache \
         mesa-dev \
     && cd /mve \
     && mkdir bin \
-    && make all
+    && make all \
+    && rm apps/Makefile \
+    && cp -r apps/* /usr/bin
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,105 @@
+// Return Repository Name
+String getRepoName() {
+    return scm.getUserRemoteConfigs()[0].getUrl().tokenize('/')[3].split("\\.")[0]
+}
+pipeline {
+    agent {
+        kubernetes {
+            defaultContainer 'kaniko'
+            yaml """
+kind: Pod
+metadata:
+  name: kaniko
+spec:
+  containers:
+  - name: kaniko
+    image: gcr.io/kaniko-project/executor:debug
+    imagePullPolicy: Always
+    command:
+    - /busybox/cat
+    tty: true
+    volumeMounts:
+      - name: jenkins-docker-cfg
+        mountPath: /kaniko/.docker
+  volumes:
+  - name: jenkins-docker-cfg
+    projected:
+      sources:
+      - secret:
+          name: harbor-registry-1
+          items:
+            - key: .dockerconfigjson
+              path: config.json
+"""
+        }
+    }
+    stages {
+        stage('Checkout Repository') {
+            steps {
+                // Checkout Repository
+                checkout scm
+                // Get Repository Name
+                script {
+                    env.repoName = getRepoName()
+                }
+            }
+            post {
+                always {
+                    //echo 'Build Started for '
+                    notifyBuild('STARTED')
+                }
+            }
+        }
+        //stage('Run Code Tests') {
+        //}
+        stage('Build with Kaniko and push to Harbor') {
+            steps {
+                container(name: 'kaniko', shell: '/busybox/sh') {
+                    withEnv(['PATH+EXTRA=/busybox']) {
+                        sh '''#!/busybox/sh
+            /kaniko/executor -f /Dockerfile -c `pwd` --destination=core.harbor.solspec.io:443/slpc/$repoName:$GIT_BRANCH
+            '''
+                    }
+                }
+            }
+            post {
+                success {
+                    //echo 'Build Started for '
+                    notifyBuild('SUCCESSFUL')
+                }
+                failure{
+                    notifyBuild("FAILED")
+                }
+            }
+        }
+    }
+}
+def notifyBuild(String buildStatus = 'STARTED') {
+    // build status of null means successful
+    buildStatus = buildStatus ?: 'SUCCESSFUL'
+    // Default values
+    def colorName = 'RED'
+    def colorCode = '#FF0000'
+    def subject = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'"
+    def summary = "${subject} (${env.BUILD_URL})"
+    def details = """<p>STARTED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':</p>
+    <p>Check console output at &QUOT;<a href='${env.BUILD_URL}'>${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>&QUOT;</p>"""
+    // Override default values based on build status
+    if (buildStatus == 'STARTED') {
+        color = 'YELLOW'
+        colorCode = '#FFFF00'
+    } else if (buildStatus == 'SUCCESSFUL') {
+        color = 'GREEN'
+        colorCode = '#00FF00'
+    } else {
+        color = 'RED'
+        colorCode = '#FF0000'
+    }
+    // Send notifications
+    slackSend(color: colorCode, message: summary)
+    //emailext(
+    //        subject: subject,
+    //        body: details,
+    //        recipientProviders: [[$class: 'DevelopersRecipientProvider']]
+    //)
+}

--- a/libs/util/system.cc
+++ b/libs/util/system.cc
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <csignal>
-#if defined(__GNUC__) && !defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(__GLIBC__) && !defined(_WIN32) && !defined(__CYGWIN__)
 #   include <execinfo.h> // ::backtrace
 #endif
 
@@ -51,7 +51,7 @@ signal_segfault_handler (int code)
 void
 print_stack_trace (void)
 {
-#if defined(__GNUC__) && !defined(_WIN32) &&  !defined(__CYGWIN__)
+#if defined(__GLIBC__) && !defined(_WIN32) &&  !defined(__CYGWIN__)
     /* Get stack pointers for all frames on the stack. */
     void *array[32];
     int const size = ::backtrace(array, 32);


### PR DESCRIPTION
The current compatibility checks in the libs/util/system.cc
check for the __GNUC__ flag when deciding whether to include
the execinfo.h header and backtrace functionalityt. The
__GNUC__ flag returns true for distros that do not inlude glibc
which will cause compilation issues for musl libc.

The check now looks for __GLIBC__ and will properly exclude the
functionality from distros using a different libc implementation.